### PR TITLE
SCP-4860 - Make tests reproducible

### DIFF
--- a/spec-test.dhall
+++ b/spec-test.dhall
@@ -18,6 +18,7 @@ in  { name = "marlowe-spec-cli"
           , "coroutines"
           , "aff-coroutines"
           , "spec"
+          , "lcg"
           ]
     , packages = ./packages.dhall
     , sources = [ "src/**/*.purs", "spec-test/**/*.purs" ]

--- a/spec-test/src/Spec/Main.purs
+++ b/spec-test/src/Spec/Main.purs
@@ -5,10 +5,12 @@ import Prelude
 import Control.JsonStream (createJsonStream)
 import Data.Argonaut (Json, decodeJson, encodeJson, stringify)
 import Data.Either (Either(..))
+import Data.Maybe (fromMaybe, maybe)
 import Effect (Effect)
 import Effect.Console (log)
 import Language.Marlowe.Core.V1.Semantics (computeTransaction, playTrace) as C
 import Node.Process (stdin)
+import Random.LCG (randomSeed)
 import Spec.GenerateRandomValue (generateRandomValue)
 import Spec.Request (Request(..))
 import Spec.Response (Response(..))
@@ -22,10 +24,13 @@ handleJsonRequest req = case decodeJson req of
       $ RequestResponse
       $ encodeJson
       $ testRoundtripSerializationJson typeId json
-  Right (GenerateRandomValue typeId) ->
-    RequestResponse
-      <<< encodeJson
-      <$> generateRandomValue 5 typeId
+  Right (GenerateRandomValue typeId mSize mSeed) -> do
+    let
+      size = fromMaybe 5 mSize
+    seed <- maybe randomSeed pure mSeed
+    pure $ RequestResponse
+      $ encodeJson
+      $ generateRandomValue seed size typeId
   Right (ComputeTransaction input state contract) ->
     pure
       $ RequestResponse


### PR DESCRIPTION
This PR adds reproducible random generation to the `GenerateRandomValue` request. It is used by [this PR](https://github.com/input-output-hk/marlowe/pull/158) in the marlowe repo