### PR TITLE
PLT-4250: `evalObservation` in spec-test

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -436,11 +436,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1676558808,
-        "narHash": "sha256-iCbCYfsa1e5J2gYF6mKOfFKS1PGHdo6wJBoLmbnAEXA=",
+        "lastModified": 1679495749,
+        "narHash": "sha256-FKlSQZ8jsmO6nyHaf33UqNxjYZdIzeID8UpgebYgJUg=",
         "owner": "input-output-hk",
         "repo": "marlowe",
-        "rev": "6afc2621128625088aff7664bdb6ded5897c5e67",
+        "rev": "d89a7127581315d76206516bf81c2e7a5c7c3b4f",
         "type": "github"
       },
       "original": {

--- a/spec-test.dhall
+++ b/spec-test.dhall
@@ -6,6 +6,7 @@ in  { name = "marlowe-spec-cli"
     , dependencies =
           marloweConf.dependencies
         # [ "console"
+          , "effect"
           , "node-process"
           , "node-streams"
           , "node-buffer"

--- a/spec-test/src/Spec/Main.purs
+++ b/spec-test/src/Spec/Main.purs
@@ -10,6 +10,7 @@ import Effect (Effect)
 import Effect.Console (log)
 import Language.Marlowe.Core.V1.Semantics
   ( computeTransaction
+  , evalObservation
   , evalValue
   , playTrace
   ) as C
@@ -50,6 +51,11 @@ handleJsonRequest req = case decodeJson req of
       $ RequestResponse
       $ encodeJson
       $ C.evalValue env state value
+  Right (EvalObservation env state observation) ->
+    pure
+      $ RequestResponse
+      $ encodeJson
+      $ C.evalObservation env state observation
 
 invalidJsonRequest :: String -> Response Json
 invalidJsonRequest = InvalidRequest

--- a/spec-test/src/Spec/Request.purs
+++ b/spec-test/src/Spec/Request.purs
@@ -12,6 +12,7 @@ import Data.Time.Duration (Milliseconds(..))
 import Language.Marlowe.Core.V1.Semantics.Types
   ( Contract
   , Environment
+  , Observation
   , State
   , Timeout
   , TransactionInput
@@ -27,6 +28,7 @@ data Request transport
   | ComputeTransaction C.TransactionInput C.State C.Contract
   | PlayTrace C.Timeout C.Contract (List C.TransactionInput)
   | EvalValue C.Environment C.State C.Value
+  | EvalObservation C.Environment C.State C.Observation
 
 instance DecodeJson (Request Json) where
   decodeJson =
@@ -39,6 +41,7 @@ instance DecodeJson (Request Json) where
       mState <- getProp "state"
       mContract <- getProp "coreContract"
       mValue <- getProp "value"
+      mObservation <- getProp "observation"
       mEnvironment <- getProp "environment"
       mInitialTime <- bindFlipped (instant <<< Milliseconds) <$> getProp
         "initialTime"
@@ -55,5 +58,7 @@ instance DecodeJson (Request Json) where
           (PlayTrace <$> mInitialTime <*> mContract <*> mTransactionInputs)
         "eval-value" -> pure
           (EvalValue <$> mEnvironment <*> mState <*> mValue)
+        "eval-observation" -> pure
+          (EvalObservation <$> mEnvironment <*> mState <*> mObservation)
         _ -> pure Nothing
 


### PR DESCRIPTION
The PR introduces `EvalObservation` to the spec-test protocol.